### PR TITLE
Add another Fritz!Box detection

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -139,6 +139,11 @@ const services = [
         type: 'img',
     },
     {
+        url: 'http://fritz.box/css/rd/logos/logo_fritzDiamond.svg',
+        name: 'AVM FRITZ!Box (http://fritz.box)',
+        type: 'img',
+    },
+    {
         url: 'https://freedombox/plinth/static/theme/img/freedombox-logo-32px.png',
         name: 'FreedomBox',
         type: 'img',


### PR DESCRIPTION
This one works with the current version on the Fritz!Box 7490.
The url, which has been implemented in PR #8, does not work with that router and the current firmware version.